### PR TITLE
Improved i18n

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -55,6 +55,7 @@ export interface Card {
 	ruleName: string;
 	parameterTypes: RuleParameterTypes;
 	parameters: RuleParameters;
+	values?: object;
 }
 
 export interface RuleParameters {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -55,7 +55,7 @@ export interface Card {
 	ruleName: string;
 	parameterTypes: RuleParameterTypes;
 	parameters: RuleParameters;
-	values?: object;
+	values?: { [key: string]: string } | undefined;
 }
 
 export interface RuleParameters {
@@ -138,14 +138,14 @@ export interface ProfileImgChangeMessage {
 export interface ErrorMessage extends MessageBase {
 	type: 'ERROR';
 	message: string;
-	values?: object;
+	values?: { [key: string]: string } | undefined;
 }
 
 export interface SystemMessage extends MessageBase {
 	type: 'SYSTEM';
 	message: string;
 	severity: Severity;
-	values?: object;
+	values?: { [key: string]: string } | undefined;
 }
 
 export type Severity = 'info' | 'warning';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -138,14 +138,14 @@ export interface ProfileImgChangeMessage {
 export interface ErrorMessage extends MessageBase {
 	type: 'ERROR';
 	message: string;
-	values?: { [key: string]: string } | undefined;
+	values?: { [key: string]: string };
 }
 
 export interface SystemMessage extends MessageBase {
 	type: 'SYSTEM';
 	message: string;
 	severity: Severity;
-	values?: { [key: string]: string } | undefined;
+	values?: { [key: string]: string };
 }
 
 export type Severity = 'info' | 'warning';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -137,12 +137,14 @@ export interface ProfileImgChangeMessage {
 export interface ErrorMessage extends MessageBase {
 	type: 'ERROR';
 	message: string;
+	values?: object;
 }
 
 export interface SystemMessage extends MessageBase {
 	type: 'SYSTEM';
 	message: string;
 	severity: Severity;
+	values?: object;
 }
 
 export type Severity = 'info' | 'warning';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -55,7 +55,7 @@ export interface Card {
 	ruleName: string;
 	parameterTypes: RuleParameterTypes;
 	parameters: RuleParameters;
-	values?: { [key: string]: string } | undefined;
+	values?: SubstitutionValues;
 }
 
 export interface RuleParameters {
@@ -64,6 +64,10 @@ export interface RuleParameters {
 
 export interface RuleParameterTypes {
 	[key: string]: RuleParameterType;
+}
+
+export interface SubstitutionValues {
+	[key: string]: string;
 }
 
 export type RuleParameterType = '' | 'player' | 'number' | string[];
@@ -138,14 +142,14 @@ export interface ProfileImgChangeMessage {
 export interface ErrorMessage extends MessageBase {
 	type: 'ERROR';
 	message: string;
-	values?: { [key: string]: string };
+	values?: SubstitutionValues;
 }
 
 export interface SystemMessage extends MessageBase {
 	type: 'SYSTEM';
 	message: string;
 	severity: Severity;
-	values?: { [key: string]: string };
+	values?: SubstitutionValues;
 }
 
 export type Severity = 'info' | 'warning';


### PR DESCRIPTION
Non-breaking changes to protocol to enable substitutions to be included with cards, system messages etc. so that localization can be done in the client. Utilized by the corresponding pull requests, both named improved_i18n, in the client and server repos