### PR TITLE
feat: include turn length in room state message

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -118,9 +118,10 @@ export interface LeaveRoomMessage extends MessageBase {
 
 export interface RoomStateMessage extends MessageBase {
 	type: 'ROOM_STATE';
-	users: User[];
+	users: User[]; // in turn order
 	turnUserId: string;
-	turnEndTime: number;
+	turnEndTime: number; // in milliseconds since Unix epoch
+	turnLength: number; // in seconds
 	enabledRules: Card[];
 	hand: Card[];
 	userId: string;


### PR DESCRIPTION
It's what it says on the tin. Corresponds to the improved_turns PRs in the server and client.